### PR TITLE
Supports Japanese documents. / Use syntax highlight in docstring.

### DIFF
--- a/src/create_pyi.py
+++ b/src/create_pyi.py
@@ -7,7 +7,7 @@ import autopep8
 import yaml
 from bs4 import BeautifulSoup, NavigableString, Tag
 
-import translater
+import translator
 from models import ArgumentData, Arguments, FunctionData, HTags, IntelliSenseOptionModel
 
 
@@ -21,7 +21,7 @@ class CreateMayaCommandPYI:
     function_name: str
     argument_data: list[ArgumentData]
     current_letter: str | None = None
-    translater: translater.Translater
+    translator: translator.Translator
 
     def __init__(
         self,
@@ -34,10 +34,10 @@ class CreateMayaCommandPYI:
         self.option = option
         if language == "jp":
             path = self.option.maya.documents[str(version)].jp
-            self.translater = translater.Jp()
+            self.translator = translator.Jp()
         else:
             path = self.option.maya.documents[str(version)].en
-            self.translater = translater.En()
+            self.translator = translator.En()
         self.document_root = Path(document_root) / path / "CommandsPython"
 
         self.export_path = Path(export_path)
@@ -165,21 +165,21 @@ class CreateMayaCommandPYI:
             hExamples_content_text = hExamples_content.get_text(strip=True)
             if not self.is_only_whitespace(hExamples_content_text):
                 hExamples_content_text = hExamples_content_text.replace("# ", "").replace("#", "---\n")
-                return f"\n{self.translater.EXAMPLE_WORD}:\n---\n```\n{hExamples_content_text}\n```\n\n---"
+                return f"\n{self.translator.EXAMPLE_WORD}:\n---\n```\n{hExamples_content_text}\n```\n\n---"
         return ""
 
     def create_docstrings_flags_texts(self) -> str:
-        text = f"\n{self.translater.FLAGS_WORD}:\n---\n\n"
+        text = f"\n{self.translator.FLAGS_WORD}:\n---\n\n"
         for argData in self.argument_data:
             types = ""
             for p in argData.properties:
-                prop = self.translater.property_mode(p)
+                prop = self.translator.property_mode(p)
                 types += f"{prop}, "
             types = types[:-2]
             text += f"""
 ---
 {argData.longName}: {argData.type}
-    {self.translater.PROPERTIES_WORD}: {types}
+    {self.translator.PROPERTIES_WORD}: {types}
     {argData.docs}
 """
         return text
@@ -243,7 +243,7 @@ URL:
         return matches.group(1) if matches else None
 
     def extract_next_p_content(self) -> None:
-        allSynopsis = self.extract_between_specific_h2_tags(f'<h2><a name="hSynopsis">{self.translater.SYNOPSIS_WORD}</a></h2>')
+        allSynopsis = self.extract_between_specific_h2_tags(f'<h2><a name="hSynopsis">{self.translator.SYNOPSIS_WORD}</a></h2>')
         soup = BeautifulSoup(allSynopsis, "html.parser")
         docs = soup.get_text()
         synopsis = soup.find("p", {"id": "synopsis"})
@@ -252,13 +252,13 @@ URL:
         while current_element and current_element.name != "h2":
             self.description += str(current_element.get_text())
             current_element = current_element.find_next_sibling()
-        note_text = self.translater.SYNOPSIS_NOTE_TEXT
+        note_text = self.translator.SYNOPSIS_NOTE_TEXT
         # description_split = self.description.split(note_text)
         # mention = description_split[1].split("\n")[0]
         # command_description = description_split[1].replace(mention, f"\n{mention}")
         synopsis_description, command_description = docs.split(note_text)
 
-        self.description = f"""{self.translater.SYNOPSIS_WORD}:
+        self.description = f"""{self.translator.SYNOPSIS_WORD}:
 ---
 ---
 {synopsis_description}
@@ -334,7 +334,7 @@ URL:
         self.return_typeHint = ""
         returns_texts: list[list[str, str]] = []
         returns = []
-        if return_content.text != self.translater.RETURN_NONE_WORD:
+        if return_content.text != self.translator.RETURN_NONE_WORD:
             soup = BeautifulSoup(str(return_content), "html.parser")
             tables = soup.find("table")
             if tables:
@@ -357,10 +357,10 @@ URL:
             else:
                 print(f"error: {self.function_name}")
         else:
-            self.return_typeHint = self.translater.RETURN_NONE_WORD
+            self.return_typeHint = self.translator.RETURN_NONE_WORD
         self.docstrings_text = ""
         if returns_texts != []:
-            self.docstrings_text = f"{self.translater.RETURN_WORD}:\n---\n\n"
+            self.docstrings_text = f"{self.translator.RETURN_WORD}:\n---\n\n"
             for returns_text in returns_texts:
                 self.docstrings_text += f"\n    {returns_text[0]}: {returns_text[1]}"
 

--- a/src/create_pyi.py
+++ b/src/create_pyi.py
@@ -357,7 +357,7 @@ URL:
             else:
                 print(f"error: {self.function_name}")
         else:
-            self.return_typeHint = self.translator.RETURN_NONE_WORD
+            self.return_typeHint = "None"
         self.docstrings_text = ""
         if returns_texts != []:
             self.docstrings_text = f"{self.translator.RETURN_WORD}:\n---\n\n"

--- a/src/create_pyi.py
+++ b/src/create_pyi.py
@@ -164,7 +164,7 @@ class CreateMayaCommandPYI:
         if hExamples_content:
             hExamples_content_text = hExamples_content.get_text(strip=True)
             if not self.is_only_whitespace(hExamples_content_text):
-                hExamples_content_text = hExamples_content_text.replace("# ", "").replace("#", "---\n")
+                # hExamples_content_text = hExamples_content_text.replace("# ", "").replace("#", "---\n")
                 return f"\n{self.translator.EXAMPLE_WORD}:\n---\n```\n{hExamples_content_text}\n```\n\n---"
         return ""
 

--- a/src/create_pyi.py
+++ b/src/create_pyi.py
@@ -165,7 +165,7 @@ class CreateMayaCommandPYI:
             hExamples_content_text = hExamples_content.get_text(strip=True)
             if not self.is_only_whitespace(hExamples_content_text):
                 hExamples_content_text = hExamples_content_text.replace("# ", "").replace("#", "---\n")
-                return f"\n{self.translater.EXAMPLE_WORD}:\n---\n{hExamples_content_text}\n\n---"
+                return f"\n{self.translater.EXAMPLE_WORD}:\n---\n```\n{hExamples_content_text}\n```\n\n---"
         return ""
 
     def create_docstrings_flags_texts(self) -> str:

--- a/src/create_pyi.py
+++ b/src/create_pyi.py
@@ -7,8 +7,8 @@ import autopep8
 import yaml
 from bs4 import BeautifulSoup, NavigableString, Tag
 
-from models import ArgumentData, Arguments, FunctionData, HTags, IntelliSenseOptionModel
 import translater
+from models import ArgumentData, Arguments, FunctionData, HTags, IntelliSenseOptionModel
 
 
 class CreateMayaCommandPYI:

--- a/src/translater.py
+++ b/src/translater.py
@@ -1,16 +1,41 @@
 from abc import ABC, abstractmethod
 
-AbstractField = lambda: property(abstractmethod(lambda s: s))
-
 
 class Translater(ABC):
-    SYNOPSIS_WORD: str = AbstractField()
-    SYNOPSIS_NOTE_TEXT: str = AbstractField()
-    FLAGS_WORD: str = AbstractField()
-    RETURN_WORD: str = AbstractField()
-    RETURN_NONE_WORD: str = AbstractField()
-    EXAMPLE_WORD: str = AbstractField()
-    PROPERTIES_WORD: str = AbstractField()
+    @property
+    @abstractmethod
+    def SYNOPSIS_WORD(self) -> str:
+        pass
+
+    @property
+    @abstractmethod
+    def SYNOPSIS_NOTE_TEXT(self) -> str:
+        pass
+
+    @property
+    @abstractmethod
+    def FLAGS_WORD(self) -> str:
+        pass
+
+    @property
+    @abstractmethod
+    def RETURN_WORD(self) -> str:
+        pass
+
+    @property
+    @abstractmethod
+    def RETURN_NONE_WORD(self) -> str:
+        pass
+
+    @property
+    @abstractmethod
+    def EXAMPLE_WORD(self) -> str:
+        pass
+
+    @property
+    @abstractmethod
+    def PROPERTIES_WORD(self) -> str:
+        pass
 
     @abstractmethod
     def property_mode(self, prop: str) -> str:
@@ -48,3 +73,5 @@ class Jp(Translater):
             return "編集"
         elif prop == "multiuse":
             return "複数"
+        else:
+            return prop

--- a/src/translater.py
+++ b/src/translater.py
@@ -13,12 +13,12 @@ class Translater(ABC):
     PROPERTIES_WORD: str = AbstractField()
 
     @abstractmethod
-    def property_mode(self, prop: str):
+    def property_mode(self, prop: str) -> str:
         pass
 
 
 class En(Translater):
-    SYNOPSIS_WORD = "Synopsis"
+    SYNOPSIS_WORD: str = "Synopsis"
     SYNOPSIS_NOTE_TEXT: str = "Note: Strings representing object names and arguments must be separated by commas. This is not depicted in the synopsis."
     FLAGS_WORD: str = "Flags"
     RETURN_WORD: str = "Return"
@@ -26,12 +26,12 @@ class En(Translater):
     EXAMPLE_WORD: str = "Example"
     PROPERTIES_WORD: str = "properties"
 
-    def property_mode(self, prop: str):
+    def property_mode(self, prop: str) -> str:
         return prop
 
 
 class Jp(Translater):
-    SYNOPSIS_WORD = "概要"
+    SYNOPSIS_WORD: str = "概要"
     SYNOPSIS_NOTE_TEXT: str = "注: オブジェクトの名前と引数を表す文字列は、カンマで区切る必要があります。これはシノプシスに示されていません。"
     FLAGS_WORD: str = "フラグ"
     RETURN_WORD: str = "戻り値"
@@ -39,7 +39,7 @@ class Jp(Translater):
     EXAMPLE_WORD: str = "例"
     PROPERTIES_WORD: str = "プロパティ"
 
-    def property_mode(self, prop: str):
+    def property_mode(self, prop: str) -> str:
         if prop == "create":
             return "作成"
         elif prop == "query":

--- a/src/translater.py
+++ b/src/translater.py
@@ -1,0 +1,50 @@
+from abc import ABC, abstractmethod
+
+AbstractField = lambda: property(abstractmethod(lambda s: s))
+
+
+class Translater(ABC):
+    SYNOPSIS_WORD: str = AbstractField()
+    SYNOPSIS_NOTE_TEXT: str = AbstractField()
+    FLAGS_WORD: str = AbstractField()
+    RETURN_WORD: str = AbstractField()
+    RETURN_NONE_WORD: str = AbstractField()
+    EXAMPLE_WORD: str = AbstractField()
+    PROPERTIES_WORD: str = AbstractField()
+
+    @abstractmethod
+    def property_mode(self, prop: str):
+        pass
+
+
+class En(Translater):
+    SYNOPSIS_WORD = "Synopsis"
+    SYNOPSIS_NOTE_TEXT: str = "Note: Strings representing object names and arguments must be separated by commas. This is not depicted in the synopsis."
+    FLAGS_WORD: str = "Flags"
+    RETURN_WORD: str = "Return"
+    RETURN_NONE_WORD: str = "None"
+    EXAMPLE_WORD: str = "Example"
+    PROPERTIES_WORD: str = "properties"
+
+    def property_mode(self, prop: str):
+        return prop
+
+
+class Jp(Translater):
+    SYNOPSIS_WORD = "概要"
+    SYNOPSIS_NOTE_TEXT: str = "注: オブジェクトの名前と引数を表す文字列は、カンマで区切る必要があります。これはシノプシスに示されていません。"
+    FLAGS_WORD: str = "フラグ"
+    RETURN_WORD: str = "戻り値"
+    RETURN_NONE_WORD: str = "なし"
+    EXAMPLE_WORD: str = "例"
+    PROPERTIES_WORD: str = "プロパティ"
+
+    def property_mode(self, prop: str):
+        if prop == "create":
+            return "作成"
+        elif prop == "query":
+            return "照会"
+        elif prop == "edit":
+            return "編集"
+        elif prop == "multiuse":
+            return "複数"

--- a/src/translator.py
+++ b/src/translator.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 
-class Translater(ABC):
+class Translator(ABC):
     @property
     @abstractmethod
     def SYNOPSIS_WORD(self) -> str:
@@ -42,7 +42,7 @@ class Translater(ABC):
         pass
 
 
-class En(Translater):
+class En(Translator):
     SYNOPSIS_WORD: str = "Synopsis"
     SYNOPSIS_NOTE_TEXT: str = "Note: Strings representing object names and arguments must be separated by commas. This is not depicted in the synopsis."
     FLAGS_WORD: str = "Flags"
@@ -55,7 +55,7 @@ class En(Translater):
         return prop
 
 
-class Jp(Translater):
+class Jp(Translator):
     SYNOPSIS_WORD: str = "概要"
     SYNOPSIS_NOTE_TEXT: str = "注: オブジェクトの名前と引数を表す文字列は、カンマで区切る必要があります。これはシノプシスに示されていません。"
     FLAGS_WORD: str = "フラグ"


### PR DESCRIPTION
## 変更点 1
--language オプションでjpを指定したときに、日本語のドキュメントをベースに生成されるように実装しました

## 変更点 2
Example / 例 部分をバッククォートで囲うことで、VSCode内でシンタックスハイライトされるようにしました

![image](https://github.com/RyotaUnzai/Autodesk-Maya-Python-IntelliSense/assets/39555991/b57bf9a5-82cb-463c-9907-a7d866b7718f)
