### PR TITLE
chore: remove mypy.ini in favor of toml configuration

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,0 @@
-[mypy]
-strict=True
-warn_return_any=True
-check_untyped_defs=True


### PR DESCRIPTION
- Deleted the mypy.ini file as the project transitions to using toml for configuration.
- This change streamlines configuration management and aligns with modern best practices.