### PR TITLE
fix: escape three back quotes in example code.

### DIFF
--- a/src/create_pyi.py
+++ b/src/create_pyi.py
@@ -169,6 +169,7 @@ class CreateMayaCommandPYI:
             hExamples_content_text = hExamples_content.get_text(strip=True)
             if not self.is_only_whitespace(hExamples_content_text):
                 # hExamples_content_text = hExamples_content_text.replace("# ", "").replace("#", "---\n")
+                hExamples_content_text.replace(r'"""', r'\"""')
                 return f"\n{self.translator.EXAMPLE_WORD}:\n---\n```\n{hExamples_content_text}\n```\n\n---"
         return ""
 


### PR DESCRIPTION
例 内のコードブロックをエスケープすることで、fファイル内のコードが正しく動作していない問題を修正しました。
#13 

![image](https://github.com/RyotaUnzai/Autodesk-Maya-Python-IntelliSense/assets/39555991/d1cb8bd1-4892-4cb3-a504-19170e8f698a)
