### PR TITLE
Update settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,7 +34,7 @@
         "C:\\Program Files\\Autodesk\\en_maya2024.2\\Python\\Lib\\site-packages",
     ],
     "python.analysis.exclude": [
-        "**\\bin",
+        ".\\bin",
     ],
     "flake8.path": [
         "${workspaceFolder}\\.venv\\Scripts\\pflake8.exe"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -33,9 +33,9 @@
         "${workspaceFolder}\\en_maya2024.2\\typings",
         "C:\\Program Files\\Autodesk\\en_maya2024.2\\Python\\Lib\\site-packages",
     ],
-    "python.analysis.diagnosticSeverityOverrides": {
-        "reportShadowedImports": "none"
-    },
+    "python.analysis.exclude": [
+        "**\\bin",
+    ],
     "flake8.path": [
         "${workspaceFolder}\\.venv\\Scripts\\pflake8.exe"
     ],


### PR DESCRIPTION
Using exclude setting for bin directory instead of diagnosticSeverityOverrides.

bin以下のPython本体で警告が出るのを抑制するために、`"reportShadowedImports": "none"` にしていると思うんですが、`python.analysis.exclude` で除外する方が適切だと思います。